### PR TITLE
feat(user): GET /api/user/{id} - obtener información pública del usuario #4

### DIFF
--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/user/GetUserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/user/GetUserUseCase.java
@@ -1,0 +1,17 @@
+package co.com.bancolombia.usecase.user;
+
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class GetUserUseCase {
+    private final UserRepository userRepository;
+
+    public Mono<User> execute(String id) {
+        return userRepository.findById(id)
+                .switchIfEmpty(Mono.error(new NotFoundException("USER_NOT_FOUND", "User not found")));
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/LoginUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/LoginUseCaseTest.java
@@ -1,0 +1,105 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.RefreshToken;
+import co.com.bancolombia.model.auth.TokenPair;
+import co.com.bancolombia.model.auth.gateways.RefreshTokenRepository;
+import co.com.bancolombia.model.exception.ForbiddenException;
+import co.com.bancolombia.model.exception.UnauthorizedException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.PasswordEncoder;
+import co.com.bancolombia.model.user.gateways.TokenProvider;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginUseCaseTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private TokenProvider tokenProvider;
+
+    private LoginUseCase useCase;
+
+    private final User activeUser = User.builder()
+            .id("user-1")
+            .email("user@test.com")
+            .passwordHash("hashed")
+            .isActive(true)
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        useCase = new LoginUseCase(userRepository, refreshTokenRepository, passwordEncoder, tokenProvider);
+    }
+
+    @Test
+    void execute_withValidCredentials_returnsTokenPair() {
+        RefreshToken savedToken = RefreshToken.builder()
+                .token("refresh-token")
+                .expiraEn(LocalDateTime.now().plusDays(7))
+                .build();
+
+        when(userRepository.getByEmail("user@test.com")).thenReturn(Mono.just(activeUser));
+        when(passwordEncoder.matches("plain", "hashed")).thenReturn(true);
+        when(tokenProvider.generateAccessToken(activeUser)).thenReturn(Mono.just("access-token"));
+        when(refreshTokenRepository.save(any())).thenReturn(Mono.just(savedToken));
+
+        StepVerifier.create(useCase.execute("user@test.com", "plain", "Android"))
+                .assertNext(pair -> {
+                    assertThat(pair.accessToken()).isEqualTo("access-token");
+                    assertThat(pair.refreshToken()).isEqualTo("refresh-token");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_whenUserNotFound_throwsUnauthorizedException() {
+        when(userRepository.getByEmail("noexiste@test.com")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("noexiste@test.com", "plain", "Android"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("INVALID_CREDENTIALS");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_whenAccountDisabled_throwsForbiddenException() {
+        User inactiveUser = activeUser.toBuilder().isActive(false).build();
+        when(userRepository.getByEmail("user@test.com")).thenReturn(Mono.just(inactiveUser));
+
+        StepVerifier.create(useCase.execute("user@test.com", "plain", "Android"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(ForbiddenException.class);
+                    assertThat(((ForbiddenException) error).getErrorCode()).isEqualTo("ACCOUNT_DISABLED");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_whenPasswordDoesNotMatch_throwsUnauthorizedException() {
+        when(userRepository.getByEmail("user@test.com")).thenReturn(Mono.just(activeUser));
+        when(passwordEncoder.matches("wrong", "hashed")).thenReturn(false);
+
+        StepVerifier.create(useCase.execute("user@test.com", "wrong", "Android"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("INVALID_CREDENTIALS");
+                })
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/LogoutUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/LogoutUseCaseTest.java
@@ -1,0 +1,65 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.RefreshToken;
+import co.com.bancolombia.model.auth.gateways.RefreshTokenRepository;
+import co.com.bancolombia.model.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutUseCaseTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private LogoutUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new LogoutUseCase(refreshTokenRepository);
+    }
+
+    @Test
+    void execute_withValidToken_revokesToken() {
+        RefreshToken token = RefreshToken.builder()
+                .token("valid-token")
+                .expiraEn(LocalDateTime.now().plusDays(7))
+                .build();
+
+        when(refreshTokenRepository.findByToken("valid-token")).thenReturn(Mono.just(token));
+        when(refreshTokenRepository.revoke("valid-token")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("valid-token"))
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_withInvalidToken_throwsUnauthorizedException() {
+        when(refreshTokenRepository.findByToken("invalid-token")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("invalid-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("INVALID_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void logoutAllDevices_revokesAllTokensForUser() {
+        when(refreshTokenRepository.revokeAllByUserId("user-1")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.logoutAllDevices("user-1"))
+                .verifyComplete();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/RefreshTokenUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/RefreshTokenUseCaseTest.java
@@ -1,0 +1,136 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.RefreshToken;
+import co.com.bancolombia.model.auth.gateways.RefreshTokenRepository;
+import co.com.bancolombia.model.exception.ForbiddenException;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.exception.UnauthorizedException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.TokenProvider;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenUseCaseTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private TokenProvider tokenProvider;
+
+    private RefreshTokenUseCase useCase;
+
+    private final User activeUser = User.builder()
+            .id("user-1")
+            .isActive(true)
+            .build();
+
+    private final RefreshToken validToken = RefreshToken.builder()
+            .token("old-token")
+            .userId("user-1")
+            .revocado(false)
+            .dispositivo("Android")
+            .expiraEn(LocalDateTime.now().plusDays(7))
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        useCase = new RefreshTokenUseCase(userRepository, refreshTokenRepository, tokenProvider);
+    }
+
+    @Test
+    void execute_withValidToken_returnsNewTokenPair() {
+        RefreshToken newToken = RefreshToken.builder().token("new-token").build();
+
+        when(refreshTokenRepository.findByToken("old-token")).thenReturn(Mono.just(validToken));
+        when(refreshTokenRepository.revoke("old-token")).thenReturn(Mono.empty());
+        when(userRepository.findById("user-1")).thenReturn(Mono.just(activeUser));
+        when(tokenProvider.generateAccessToken(activeUser)).thenReturn(Mono.just("new-access-token"));
+        when(refreshTokenRepository.save(any())).thenReturn(Mono.just(newToken));
+
+        StepVerifier.create(useCase.execute("old-token"))
+                .assertNext(pair -> {
+                    assertThat(pair.accessToken()).isEqualTo("new-access-token");
+                    assertThat(pair.refreshToken()).isEqualTo("new-token");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_withInvalidToken_throwsUnauthorizedException() {
+        when(refreshTokenRepository.findByToken("bad-token")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("bad-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("INVALID_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_withRevokedToken_throwsUnauthorizedException() {
+        RefreshToken revoked = validToken.toBuilder().revocado(true).build();
+        when(refreshTokenRepository.findByToken("old-token")).thenReturn(Mono.just(revoked));
+
+        StepVerifier.create(useCase.execute("old-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("TOKEN_REVOKED");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_withExpiredToken_throwsUnauthorizedException() {
+        RefreshToken expired = validToken.toBuilder().expiraEn(LocalDateTime.now().minusDays(1)).build();
+        when(refreshTokenRepository.findByToken("old-token")).thenReturn(Mono.just(expired));
+
+        StepVerifier.create(useCase.execute("old-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("TOKEN_EXPIRED");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_whenUserNotFound_throwsNotFoundException() {
+        when(refreshTokenRepository.findByToken("old-token")).thenReturn(Mono.just(validToken));
+        when(refreshTokenRepository.revoke("old-token")).thenReturn(Mono.empty());
+        when(userRepository.findById("user-1")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("old-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(NotFoundException.class);
+                    assertThat(((NotFoundException) error).getErrorCode()).isEqualTo("USER_NOT_FOUND");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_whenUserDisabled_throwsForbiddenException() {
+        User inactiveUser = activeUser.toBuilder().isActive(false).build();
+        when(refreshTokenRepository.findByToken("old-token")).thenReturn(Mono.just(validToken));
+        when(refreshTokenRepository.revoke("old-token")).thenReturn(Mono.empty());
+        when(userRepository.findById("user-1")).thenReturn(Mono.just(inactiveUser));
+
+        StepVerifier.create(useCase.execute("old-token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(ForbiddenException.class);
+                    assertThat(((ForbiddenException) error).getErrorCode()).isEqualTo("ACCOUNT_DISABLED");
+                })
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/RequestPasswordResetUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/RequestPasswordResetUseCaseTest.java
@@ -1,0 +1,63 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.PasswordReset;
+import co.com.bancolombia.model.auth.gateways.PasswordResetRepository;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestPasswordResetUseCaseTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordResetRepository passwordResetRepository;
+
+    private RequestPasswordResetUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new RequestPasswordResetUseCase(userRepository, passwordResetRepository);
+    }
+
+    @Test
+    void execute_whenEmailExists_savesResetAndReturnsToken() {
+        User user = User.builder().id("user-1").email("user@test.com").build();
+        PasswordReset saved = PasswordReset.builder()
+                .id("reset-1")
+                .userId("user-1")
+                .expiraEn(LocalDateTime.now().plusMinutes(30))
+                .build();
+
+        when(userRepository.getByEmail("user@test.com")).thenReturn(Mono.just(user));
+        when(passwordResetRepository.save(any())).thenReturn(Mono.just(saved));
+
+        StepVerifier.create(useCase.execute("user@test.com"))
+                .assertNext(token -> assertThat(token).isNotBlank())
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_whenEmailNotFound_throwsNotFoundException() {
+        when(userRepository.getByEmail("noexiste@test.com")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("noexiste@test.com"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(NotFoundException.class);
+                    assertThat(((NotFoundException) error).getErrorCode()).isEqualTo("EMAIL_NOT_FOUND");
+                })
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/ResetPasswordUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/ResetPasswordUseCaseTest.java
@@ -1,0 +1,87 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.PasswordReset;
+import co.com.bancolombia.model.auth.gateways.PasswordResetRepository;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.exception.ValidationException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.PasswordEncoder;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ResetPasswordUseCaseTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordResetRepository passwordResetRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    private ResetPasswordUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ResetPasswordUseCase(userRepository, passwordResetRepository, passwordEncoder);
+    }
+
+    @Test
+    void execute_withValidToken_updatesPasswordAndMarksTokenUsed() {
+        User user = User.builder().id("user-1").email("user@test.com").passwordHash("old-hash").build();
+        PasswordReset reset = PasswordReset.builder()
+                .id("reset-1")
+                .userId("user-1")
+                .expiraEn(LocalDateTime.now().plusMinutes(30))
+                .build();
+
+        when(passwordResetRepository.findActiveByTokenHash(anyString())).thenReturn(Mono.just(reset));
+        when(userRepository.findById("user-1")).thenReturn(Mono.just(user));
+        when(passwordEncoder.encode("new-password")).thenReturn("new-hash");
+        when(userRepository.updateUser(any())).thenReturn(Mono.just(user));
+        when(passwordResetRepository.markAsUsed(anyString())).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("plain-token", "new-password"))
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_withInvalidToken_throwsValidationException() {
+        when(passwordResetRepository.findActiveByTokenHash(anyString())).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("invalid-token", "new-password"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(ValidationException.class);
+                    assertThat(((ValidationException) error).getErrorCode()).isEqualTo("INVALID_RESET_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_whenUserNotFound_throwsNotFoundException() {
+        PasswordReset reset = PasswordReset.builder()
+                .userId("user-1")
+                .expiraEn(LocalDateTime.now().plusMinutes(30))
+                .build();
+
+        when(passwordResetRepository.findActiveByTokenHash(anyString())).thenReturn(Mono.just(reset));
+        when(userRepository.findById("user-1")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("plain-token", "new-password"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(NotFoundException.class);
+                    assertThat(((NotFoundException) error).getErrorCode()).isEqualTo("USER_NOT_FOUND");
+                })
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/user/CreateUserUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/user/CreateUserUseCaseTest.java
@@ -1,0 +1,67 @@
+package co.com.bancolombia.usecase.user;
+
+import co.com.bancolombia.model.exception.ConflictException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.PasswordEncoder;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateUserUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private CreateUserUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateUserUseCase(userRepository, passwordEncoder);
+    }
+
+    @Test
+    void execute_whenEmailNotRegistered_createsUserWithDefaults() {
+        User input = User.builder().email("nuevo@test.com").passwordHash("plain123").build();
+        when(userRepository.getByEmail("nuevo@test.com")).thenReturn(Mono.empty());
+        when(passwordEncoder.encode("plain123")).thenReturn("hashed123");
+        when(userRepository.saveUser(any())).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+        StepVerifier.create(useCase.execute(input))
+                .assertNext(saved -> {
+                    assertThat(saved.getId()).isNotNull();
+                    assertThat(saved.getPasswordHash()).isEqualTo("hashed123");
+                    assertThat(saved.isActive()).isTrue();
+                    assertThat(saved.isEmailVerified()).isFalse();
+                    assertThat(saved.getCreatedAt()).isNotNull();
+                    assertThat(saved.getUpdatedAt()).isNotNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_whenEmailAlreadyExists_throwsConflictException() {
+        User existing = User.builder().email("existe@test.com").build();
+        User input = User.builder().email("existe@test.com").build();
+        when(userRepository.getByEmail("existe@test.com")).thenReturn(Mono.just(existing));
+
+        StepVerifier.create(useCase.execute(input))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(ConflictException.class);
+                    assertThat(((ConflictException) error).getErrorCode()).isEqualTo("USER_ALREADY_EXISTS");
+                })
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/user/GetUserUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/user/GetUserUseCaseTest.java
@@ -1,0 +1,54 @@
+package co.com.bancolombia.usecase.user;
+
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private GetUserUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetUserUseCase(userRepository);
+    }
+
+    @Test
+    void execute_whenUserExists_returnsUser() {
+        User user = User.builder().id("123").fullName("María García").email("maria@test.com").build();
+        when(userRepository.findById("123")).thenReturn(Mono.just(user));
+
+        StepVerifier.create(useCase.execute("123"))
+                .assertNext(result -> {
+                    assertThat(result.getId()).isEqualTo("123");
+                    assertThat(result.getEmail()).isEqualTo("maria@test.com");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_whenUserNotFound_throwsNotFoundException() {
+        when(userRepository.findById("999")).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute("999"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(NotFoundException.class);
+                    assertThat(((NotFoundException) error).getErrorCode()).isEqualTo("USER_NOT_FOUND");
+                })
+                .verify();
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/config/PostgreSQLConnectionPoolTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/config/PostgreSQLConnectionPoolTest.java
@@ -1,0 +1,22 @@
+package co.com.bancolombia.r2dbc.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgreSQLConnectionPoolTest {
+
+    @Test
+    void constants_haveExpectedPoolValues() {
+        assertThat(PostgreSQLConnectionPool.INITIAL_SIZE).isEqualTo(12);
+        assertThat(PostgreSQLConnectionPool.MAX_SIZE).isEqualTo(15);
+        assertThat(PostgreSQLConnectionPool.MAX_IDLE_TIME).isEqualTo(30);
+        assertThat(PostgreSQLConnectionPool.DEFAULT_PORT).isEqualTo(5432);
+    }
+
+    @Test
+    void constants_initialSizeIsLessThanOrEqualToMaxSize() {
+        assertThat(PostgreSQLConnectionPool.INITIAL_SIZE)
+                .isLessThanOrEqualTo(PostgreSQLConnectionPool.MAX_SIZE);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/config/PostgresqlConnectionPropertiesTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/config/PostgresqlConnectionPropertiesTest.java
@@ -1,0 +1,22 @@
+package co.com.bancolombia.r2dbc.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresqlConnectionPropertiesTest {
+
+    @Test
+    void constructor_storesAllPropertiesCorrectly() {
+        PostgresqlConnectionProperties props = new PostgresqlConnectionProperties(
+                "localhost", 5432, "ms_user", "public", "postgres", "secret"
+        );
+
+        assertThat(props.host()).isEqualTo("localhost");
+        assertThat(props.port()).isEqualTo(5432);
+        assertThat(props.database()).isEqualTo("ms_user");
+        assertThat(props.schema()).isEqualTo("public");
+        assertThat(props.username()).isEqualTo("postgres");
+        assertThat(props.password()).isEqualTo("secret");
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/token/PasswordResetRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/token/PasswordResetRepositoryAdapterTest.java
@@ -1,0 +1,86 @@
+package co.com.bancolombia.r2dbc.token;
+
+import co.com.bancolombia.model.auth.PasswordReset;
+import co.com.bancolombia.r2dbc.entity.PasswordResetEntity;
+import co.com.bancolombia.r2dbc.mapper.PasswordResetMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetRepositoryAdapterTest {
+
+    @Mock private PasswordResetReactiveRepository repository;
+    @Mock private PasswordResetMapper mapper;
+
+    private PasswordResetRepositoryAdapter adapter;
+
+    private final PasswordResetEntity entity = PasswordResetEntity.builder()
+            .id("reset-1").userId("user-1").tokenHash("hash-abc")
+            .expiraEn(LocalDateTime.now().plusMinutes(30)).usado(false).build();
+
+    private final PasswordReset domain = PasswordReset.builder()
+            .id("reset-1").userId("user-1").tokenHash("hash-abc")
+            .expiraEn(LocalDateTime.now().plusMinutes(30)).usado(false).build();
+
+    @BeforeEach
+    void setUp() {
+        adapter = new PasswordResetRepositoryAdapter(repository, mapper);
+    }
+
+    @Test
+    void save_mapsToEntitySavesAndMapsBack() {
+        when(mapper.toPasswordResetEntity(domain)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(Mono.just(entity));
+        when(mapper.toPasswordReset(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.save(domain))
+                .assertNext(result -> {
+                    assertThat(result.getUserId()).isEqualTo("user-1");
+                    assertThat(result.getTokenHash()).isEqualTo("hash-abc");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void findActiveByTokenHash_delegatesToRepositoryWithCurrentTimeAndMaps() {
+        when(repository.findActiveByTokenHash(eq("hash-abc"), any(LocalDateTime.class)))
+                .thenReturn(Mono.just(entity));
+        when(mapper.toPasswordReset(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.findActiveByTokenHash("hash-abc"))
+                .assertNext(result -> assertThat(result.getUserId()).isEqualTo("user-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    void findActiveByTokenHash_whenNotFound_returnsEmpty() {
+        when(repository.findActiveByTokenHash(eq("expired-hash"), any(LocalDateTime.class)))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(adapter.findActiveByTokenHash("expired-hash"))
+                .verifyComplete();
+    }
+
+    @Test
+    void markAsUsed_delegatesToRepositoryAndCompletesEmpty() {
+        when(repository.markAsUsed("hash-abc")).thenReturn(Mono.just(1));
+
+        StepVerifier.create(adapter.markAsUsed("hash-abc"))
+                .verifyComplete();
+
+        verify(repository).markAsUsed("hash-abc");
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/token/RefreshTokenRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/token/RefreshTokenRepositoryAdapterTest.java
@@ -1,0 +1,89 @@
+package co.com.bancolombia.r2dbc.token;
+
+import co.com.bancolombia.model.auth.RefreshToken;
+import co.com.bancolombia.r2dbc.entity.RefreshTokenEntity;
+import co.com.bancolombia.r2dbc.mapper.RefreshTokenMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenRepositoryAdapterTest {
+
+    @Mock private RefreshTokenReactiveRepository repository;
+    @Mock private RefreshTokenMapper mapper;
+
+    private RefreshTokenRepositoryAdapter adapter;
+
+    private final RefreshTokenEntity entity = RefreshTokenEntity.builder()
+            .id("token-1").token("raw-token").userId("user-1")
+            .expiraEn(LocalDateTime.now().plusDays(7)).build();
+
+    private final RefreshToken domain = RefreshToken.builder()
+            .id("token-1").token("raw-token").userId("user-1")
+            .expiraEn(LocalDateTime.now().plusDays(7)).build();
+
+    @BeforeEach
+    void setUp() {
+        adapter = new RefreshTokenRepositoryAdapter(repository, mapper);
+    }
+
+    @Test
+    void save_mapsToEntitySavesAndMapsBack() {
+        when(mapper.toRefreshTokenEntity(domain)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(Mono.just(entity));
+        when(mapper.toRefreshToken(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.save(domain))
+                .assertNext(result -> assertThat(result.getToken()).isEqualTo("raw-token"))
+                .verifyComplete();
+    }
+
+    @Test
+    void findByToken_delegatesToRepositoryAndMaps() {
+        when(repository.findByToken("raw-token")).thenReturn(Mono.just(entity));
+        when(mapper.toRefreshToken(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.findByToken("raw-token"))
+                .assertNext(result -> assertThat(result.getUserId()).isEqualTo("user-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    void findByToken_whenNotFound_returnsEmpty() {
+        when(repository.findByToken("unknown")).thenReturn(Mono.empty());
+
+        StepVerifier.create(adapter.findByToken("unknown"))
+                .verifyComplete();
+    }
+
+    @Test
+    void revoke_delegatesToRepositoryAndCompletesEmpty() {
+        when(repository.revokeByToken("raw-token")).thenReturn(Mono.just(1));
+
+        StepVerifier.create(adapter.revoke("raw-token"))
+                .verifyComplete();
+
+        verify(repository).revokeByToken("raw-token");
+    }
+
+    @Test
+    void revokeAllByUserId_delegatesToRepositoryAndCompletesEmpty() {
+        when(repository.revokeAllByUserId("user-1")).thenReturn(Mono.just(3));
+
+        StepVerifier.create(adapter.revokeAllByUserId("user-1"))
+                .verifyComplete();
+
+        verify(repository).revokeAllByUserId("user-1");
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/user/UserRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/bancolombia/r2dbc/user/UserRepositoryAdapterTest.java
@@ -1,0 +1,126 @@
+package co.com.bancolombia.r2dbc.user;
+
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.r2dbc.entity.UserEntity;
+import co.com.bancolombia.r2dbc.mapper.UserMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryAdapterTest {
+
+    @Mock private UserReactiveRepository repository;
+    @Mock private UserMapper mapper;
+
+    private UserRepositoryAdapter adapter;
+
+    private final UserEntity entity = UserEntity.builder()
+            .id("user-1").email("user@test.com").fullName("Test User").build();
+
+    private final User domain = User.builder()
+            .id("user-1").email("user@test.com").fullName("Test User").build();
+
+    @BeforeEach
+    void setUp() {
+        adapter = new UserRepositoryAdapter(repository, mapper);
+    }
+
+    @Test
+    void saveUser_mapsToEntitySetsNewRecordAndSaves() {
+        when(mapper.toUserEntity(domain)).thenReturn(entity);
+        when(repository.save(any())).thenReturn(Mono.just(entity));
+        when(mapper.toUser(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.saveUser(domain))
+                .assertNext(result -> assertThat(result.getId()).isEqualTo("user-1"))
+                .verifyComplete();
+
+        verify(repository).save(any(UserEntity.class));
+    }
+
+    @Test
+    void findById_delegatesToRepositoryAndMaps() {
+        when(repository.findById("user-1")).thenReturn(Mono.just(entity));
+        when(mapper.toUser(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.findById("user-1"))
+                .assertNext(result -> assertThat(result.getEmail()).isEqualTo("user@test.com"))
+                .verifyComplete();
+    }
+
+    @Test
+    void findById_whenNotFound_returnsEmpty() {
+        when(repository.findById("unknown")).thenReturn(Mono.empty());
+
+        StepVerifier.create(adapter.findById("unknown"))
+                .verifyComplete();
+    }
+
+    @Test
+    void getByEmail_delegatesToRepositoryAndMaps() {
+        when(repository.findByEmail("user@test.com")).thenReturn(Mono.just(entity));
+        when(mapper.toUser(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.getByEmail("user@test.com"))
+                .assertNext(result -> assertThat(result.getId()).isEqualTo("user-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    void updateUser_savesEntityAndMaps() {
+        when(mapper.toUserEntity(domain)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(Mono.just(entity));
+        when(mapper.toUser(entity)).thenReturn(domain);
+
+        StepVerifier.create(adapter.updateUser(domain))
+                .assertNext(result -> assertThat(result.getId()).isEqualTo("user-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    void desactivateUser_whenUserExists_returnsTrue() {
+        when(repository.deactivateByEmail("user@test.com")).thenReturn(Mono.just(1));
+
+        StepVerifier.create(adapter.desactivateUser("user@test.com"))
+                .assertNext(result -> assertThat(result).isTrue())
+                .verifyComplete();
+    }
+
+    @Test
+    void desactivateUser_whenUserNotFound_returnsFalse() {
+        when(repository.deactivateByEmail("noexiste@test.com")).thenReturn(Mono.just(0));
+
+        StepVerifier.create(adapter.desactivateUser("noexiste@test.com"))
+                .assertNext(result -> assertThat(result).isFalse())
+                .verifyComplete();
+    }
+
+    @Test
+    void activateUser_whenUserExists_returnsTrue() {
+        when(repository.activateByEmail("user@test.com")).thenReturn(Mono.just(1));
+
+        StepVerifier.create(adapter.activateUser("user@test.com"))
+                .assertNext(result -> assertThat(result).isTrue())
+                .verifyComplete();
+    }
+
+    @Test
+    void deleteUser_delegatesToRepository() {
+        when(repository.deleteByEmail("user@test.com")).thenReturn(Mono.empty());
+
+        StepVerifier.create(adapter.deleteUser("user@test.com"))
+                .verifyComplete();
+
+        verify(repository).deleteByEmail("user@test.com");
+    }
+}

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -12,10 +12,4 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-
-    // Cucumber BDD
-    testImplementation 'io.cucumber:cucumber-java:7.20.1'
-    testImplementation 'io.cucumber:cucumber-spring:7.20.1'
-    testImplementation 'io.cucumber:cucumber-junit-platform-engine:7.20.1'
-    testImplementation 'org.junit.platform:junit-platform-suite:1.11.4'
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
@@ -1,11 +1,11 @@
 package co.com.bancolombia.api.auth;
 
-import co.com.bancolombia.api.dto.LoginRequest;
-import co.com.bancolombia.api.dto.MessageResponse;
-import co.com.bancolombia.api.dto.PasswordResetRequest;
-import co.com.bancolombia.api.dto.RefreshRequest;
-import co.com.bancolombia.api.dto.ResetPasswordRequest;
-import co.com.bancolombia.api.dto.TokenResponse;
+import co.com.bancolombia.api.dto.user.LoginRequest;
+import co.com.bancolombia.api.dto.token.MessageResponse;
+import co.com.bancolombia.api.dto.token.PasswordResetRequest;
+import co.com.bancolombia.api.dto.token.RefreshRequest;
+import co.com.bancolombia.api.dto.token.ResetPasswordRequest;
+import co.com.bancolombia.api.dto.token.TokenResponse;
 import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.usecase.security.LoginUseCase;
 import co.com.bancolombia.usecase.security.LogoutUseCase;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthRouterRest.java
@@ -1,12 +1,12 @@
 package co.com.bancolombia.api.auth;
 
-import co.com.bancolombia.api.dto.ErrorResponse;
-import co.com.bancolombia.api.dto.LoginRequest;
-import co.com.bancolombia.api.dto.MessageResponse;
-import co.com.bancolombia.api.dto.PasswordResetRequest;
-import co.com.bancolombia.api.dto.RefreshRequest;
-import co.com.bancolombia.api.dto.ResetPasswordRequest;
-import co.com.bancolombia.api.dto.TokenResponse;
+import co.com.bancolombia.api.dto.common.ErrorResponse;
+import co.com.bancolombia.api.dto.user.LoginRequest;
+import co.com.bancolombia.api.dto.token.MessageResponse;
+import co.com.bancolombia.api.dto.token.PasswordResetRequest;
+import co.com.bancolombia.api.dto.token.RefreshRequest;
+import co.com.bancolombia.api.dto.token.ResetPasswordRequest;
+import co.com.bancolombia.api.dto.token.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/GlobalErrorHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/GlobalErrorHandler.java
@@ -1,6 +1,6 @@
 package co.com.bancolombia.api.config;
 
-import co.com.bancolombia.api.dto.ErrorResponse;
+import co.com.bancolombia.api.dto.common.ErrorResponse;
 import co.com.bancolombia.model.exception.ConflictException;
 import co.com.bancolombia.model.exception.DomainException;
 import co.com.bancolombia.model.exception.ForbiddenException;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/common/ErrorResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/common/ErrorResponse.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.common;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/MessageResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/MessageResponse.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.token;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/PasswordResetRequest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/PasswordResetRequest.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.token;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/RefreshRequest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/RefreshRequest.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.token;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/ResetPasswordRequest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/ResetPasswordRequest.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.token;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/TokenResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/TokenResponse.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.token;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/CreateUserDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/CreateUserDto.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
@@ -75,12 +75,4 @@ public class CreateUserDto {
         requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String country;
-
-    @Schema(
-        description = "Indica si el email ya fue verificado. Normalmente false al registrarse.",
-        example = "false",
-        defaultValue = "false",
-        requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    private boolean emailVerified;
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/LoginRequest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/LoginRequest.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.api.dto;
+package co.com.bancolombia.api.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/UserResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/UserResponse.java
@@ -1,0 +1,59 @@
+package co.com.bancolombia.api.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Respuesta del sistema cuando solicitan la informacion de un usuario desde un servicio publico")
+public record UserResponse (
+        @Schema(
+                description = "Id del usuario",
+                example = "1234-asda-3433",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String id,
+        @Schema(
+                description = "Nombre completo del usuario",
+                example = "María García López",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String fullName,
+        @Schema(
+                description = "Dirección de email única del usuario. Se usará para autenticación y notificaciones.",
+                example = "maria.garcia@ejemplo.com",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String email,
+        @Schema(
+            description = "URL de la foto de perfil del usuario (opcional)",
+            example = "https://storage.ejemplo.com/fotos/maria-garcia.jpg",
+            requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String urlPhoto,
+        @Schema(
+                description = "Ciudad de residencia del usuario (opcional)",
+                example = "Medellín",
+                maxLength = 100,
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String city,
+        @Schema(
+                description = "Departamento o estado de residencia del usuario (opcional)",
+                example = "Antioquia",
+                maxLength = 100,
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String department,
+        @Schema(
+                description = "País de residencia del usuario (opcional)",
+                example = "Colombia",
+                maxLength = 100,
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        String country,
+        @Schema(
+                description = "Indica si el email ya fue verificado. Normalmente false al registrarse.",
+                example = "false",
+                defaultValue = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        boolean emailVerified
+) {}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/UserResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/user/UserResponse.java
@@ -17,12 +17,6 @@ public record UserResponse (
         )
         String fullName,
         @Schema(
-                description = "Dirección de email única del usuario. Se usará para autenticación y notificaciones.",
-                example = "maria.garcia@ejemplo.com",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        String email,
-        @Schema(
             description = "URL de la foto de perfil del usuario (opcional)",
             example = "https://storage.ejemplo.com/fotos/maria-garcia.jpg",
             requiredMode = Schema.RequiredMode.REQUIRED

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/mapper/UserMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.api.mapper;
 
-import co.com.bancolombia.api.dto.CreateUserDto;
+import co.com.bancolombia.api.dto.user.CreateUserDto;
+import co.com.bancolombia.api.dto.user.UserResponse;
 import co.com.bancolombia.model.user.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -9,4 +10,5 @@ import org.mapstruct.Mapping;
 public interface UserMapper {
     @Mapping(source = "password", target = "passwordHash")
     User toUser(CreateUserDto userDto);
+    UserResponse toResponse(User user);
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserHandler.java
@@ -1,8 +1,9 @@
 package co.com.bancolombia.api.user;
 
-import co.com.bancolombia.api.dto.CreateUserDto;
+import co.com.bancolombia.api.dto.user.CreateUserDto;
 import co.com.bancolombia.api.mapper.UserMapper;
 import co.com.bancolombia.usecase.user.CreateUserUseCase;
+import co.com.bancolombia.usecase.user.GetUserUseCase;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -20,6 +21,7 @@ import java.util.Set;
 public class UserHandler {
     private final Validator validator;
     private final CreateUserUseCase createUserUseCase;
+    private final GetUserUseCase getUserUseCase;
     private final UserMapper mapper;
 
     public Mono<ServerResponse> createUser(ServerRequest request) {
@@ -27,7 +29,20 @@ public class UserHandler {
                 .doOnNext(this::validate)
                 .map(mapper::toUser)
                 .flatMap(createUserUseCase::execute)
-                .flatMap(user -> ServerResponse.status(HttpStatus.CREATED).bodyValue(user));
+                .flatMap(user -> ServerResponse
+                        .status(HttpStatus.CREATED)
+                        .bodyValue(mapper.toResponse(user))
+                );
+    }
+
+    public Mono<ServerResponse> getUser(ServerRequest request) {
+        String id = request.pathVariable("id");
+
+        return getUserUseCase.execute(id)
+                .flatMap(user ->  ServerResponse
+                        .ok()
+                        .bodyValue(mapper.toResponse(user))
+                );
     }
 
     private void validate(Object dto) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserHandler.java
@@ -26,7 +26,13 @@ public class UserHandler {
 
     public Mono<ServerResponse> createUser(ServerRequest request) {
         return request.bodyToMono(CreateUserDto.class)
-                .doOnNext(this::validate)
+                .flatMap(dto -> {
+                    Set<ConstraintViolation<Object>> violations = validator.validate(dto);
+                    if (!violations.isEmpty()) {
+                        return Mono.error(new ConstraintViolationException(violations));
+                    }
+                    return Mono.just(dto);
+                })
                 .map(mapper::toUser)
                 .flatMap(createUserUseCase::execute)
                 .flatMap(user -> ServerResponse
@@ -43,12 +49,5 @@ public class UserHandler {
                         .ok()
                         .bodyValue(mapper.toResponse(user))
                 );
-    }
-
-    private void validate(Object dto) {
-        Set<ConstraintViolation<Object>> violations = validator.validate(dto);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserRouterRest.java
@@ -1,9 +1,11 @@
 package co.com.bancolombia.api.user;
 
-import co.com.bancolombia.api.dto.CreateUserDto;
-import co.com.bancolombia.api.dto.ErrorResponse;
-import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.api.dto.common.ErrorResponse;
+import co.com.bancolombia.api.dto.user.CreateUserDto;
+import co.com.bancolombia.api.dto.user.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
@@ -48,7 +51,7 @@ public class UserRouterRest {
                         description = "Usuario creado exitosamente",
                         content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = User.class)
+                            schema = @Schema(implementation = UserResponse.class)
                         )
                     ),
                     @ApiResponse(
@@ -77,12 +80,58 @@ public class UserRouterRest {
                     )
                 }
             )
+        ),
+        @RouterOperation(
+            path = "/api/user/{id}",
+            method = RequestMethod.GET,
+            beanClass = UserHandler.class,
+            beanMethod = "getUser",
+            operation = @Operation(
+                operationId = "getUser",
+                summary = "Obtener información pública de un usuario",
+                description = "Retorna la información no sensible de un usuario dado su ID. Endpoint de acceso público.",
+                tags = {"Usuarios"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "Identificador único del usuario",
+                        schema = @Schema(type = "string", example = "1234-asda-3433")
+                    )
+                },
+                responses = {
+                    @ApiResponse(
+                        responseCode = "200",
+                        description = "Información del usuario obtenida exitosamente",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Usuario no encontrado",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
         )
     })
     @Bean
     public RouterFunction<ServerResponse> routerFunction(UserHandler userHandler) {
-        return route(
-                POST("api/user"), userHandler::createUser
-        );
+        return route(POST("/api/user"), userHandler::createUser)
+                .andRoute(GET("/api/user/{id}"), userHandler::getUser);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/user/UserRouterRest.java
@@ -19,8 +19,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
-import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
 @Configuration
@@ -132,6 +131,6 @@ public class UserRouterRest {
     @Bean
     public RouterFunction<ServerResponse> routerFunction(UserHandler userHandler) {
         return route(POST("/api/user"), userHandler::createUser)
-                .andRoute(GET("/api/user/{id}"), userHandler::getUser);
+                .andRoute(GET("/api/user/{id}").and(accept(MediaType.APPLICATION_JSON)), userHandler::getUser);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
@@ -1,0 +1,149 @@
+package co.com.bancolombia.api.auth;
+
+import co.com.bancolombia.api.dto.token.PasswordResetRequest;
+import co.com.bancolombia.api.dto.token.RefreshRequest;
+import co.com.bancolombia.api.dto.token.ResetPasswordRequest;
+import co.com.bancolombia.api.dto.token.TokenResponse;
+import co.com.bancolombia.api.dto.user.LoginRequest;
+import co.com.bancolombia.model.auth.TokenPair;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.usecase.security.LoginUseCase;
+import co.com.bancolombia.usecase.security.LogoutUseCase;
+import co.com.bancolombia.usecase.security.RefreshTokenUseCase;
+import co.com.bancolombia.usecase.security.RequestPasswordResetUseCase;
+import co.com.bancolombia.usecase.security.ResetPasswordUseCase;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthHandlerTest {
+
+    @Mock private LoginUseCase loginUseCase;
+    @Mock private LogoutUseCase logoutUseCase;
+    @Mock private RefreshTokenUseCase refreshTokenUseCase;
+    @Mock private RequestPasswordResetUseCase requestPasswordResetUseCase;
+    @Mock private ResetPasswordUseCase resetPasswordUseCase;
+    @Mock private Validator validator;
+    @Mock private ServerRequest serverRequest;
+    @Mock private ServerRequest.Headers headers;
+
+    private AuthHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new AuthHandler(loginUseCase, logoutUseCase, refreshTokenUseCase,
+                requestPasswordResetUseCase, resetPasswordUseCase, validator);
+        when(validator.validate(any())).thenReturn(Set.of());
+    }
+
+    @Test
+    void login_withValidCredentials_returns200WithTokenPair() {
+        LoginRequest req = new LoginRequest("user@test.com", "pass123");
+        TokenPair pair = new TokenPair("access-token", "refresh-token");
+
+        when(serverRequest.bodyToMono(LoginRequest.class)).thenReturn(Mono.just(req));
+        when(serverRequest.headers()).thenReturn(headers);
+        when(headers.firstHeader("User-Agent")).thenReturn("Mozilla/5.0");
+        when(loginUseCase.execute("user@test.com", "pass123", "Mozilla/5.0")).thenReturn(Mono.just(pair));
+
+        StepVerifier.create(handler.login(serverRequest))
+                .assertNext(response -> {
+                    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void login_withInvalidBody_throwsConstraintViolationException() {
+        LoginRequest req = new LoginRequest("", "");
+        ConstraintViolation<Object> violation = mock(ConstraintViolation.class);
+
+        when(serverRequest.bodyToMono(LoginRequest.class)).thenReturn(Mono.just(req));
+        when(validator.validate(any())).thenReturn(Set.of(violation));
+
+        StepVerifier.create(handler.login(serverRequest))
+                .expectError(ConstraintViolationException.class)
+                .verify();
+    }
+
+    @Test
+    void refresh_withValidToken_returns200WithNewTokenPair() {
+        RefreshRequest req = new RefreshRequest("old-token");
+        TokenPair pair = new TokenPair("new-access", "new-refresh");
+
+        when(serverRequest.bodyToMono(RefreshRequest.class)).thenReturn(Mono.just(req));
+        when(refreshTokenUseCase.execute("old-token")).thenReturn(Mono.just(pair));
+
+        StepVerifier.create(handler.refresh(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+
+    @Test
+    void logout_withValidToken_returns204() {
+        RefreshRequest req = new RefreshRequest("valid-token");
+
+        when(serverRequest.bodyToMono(RefreshRequest.class)).thenReturn(Mono.just(req));
+        when(logoutUseCase.execute("valid-token")).thenReturn(Mono.empty());
+
+        StepVerifier.create(handler.logout(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT))
+                .verifyComplete();
+    }
+
+    @Test
+    void requestPasswordReset_whenEmailExists_returns200WithGenericMessage() {
+        PasswordResetRequest req = new PasswordResetRequest("user@test.com");
+
+        when(serverRequest.bodyToMono(PasswordResetRequest.class)).thenReturn(Mono.just(req));
+        when(requestPasswordResetUseCase.execute("user@test.com")).thenReturn(Mono.just("plain-token"));
+
+        StepVerifier.create(handler.requestPasswordReset(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+
+    @Test
+    void requestPasswordReset_whenEmailNotFound_returns200WithSameMessage() {
+        PasswordResetRequest req = new PasswordResetRequest("noexiste@test.com");
+
+        when(serverRequest.bodyToMono(PasswordResetRequest.class)).thenReturn(Mono.just(req));
+        when(requestPasswordResetUseCase.execute("noexiste@test.com"))
+                .thenReturn(Mono.error(new NotFoundException("EMAIL_NOT_FOUND", "No existe")));
+
+        StepVerifier.create(handler.requestPasswordReset(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+
+    @Test
+    void resetPassword_withValidToken_returns200() {
+        ResetPasswordRequest req = new ResetPasswordRequest("valid-token", "NewPass123!");
+
+        when(serverRequest.bodyToMono(ResetPasswordRequest.class)).thenReturn(Mono.just(req));
+        when(resetPasswordUseCase.execute("valid-token", "NewPass123!")).thenReturn(Mono.empty());
+
+        StepVerifier.create(handler.resetPassword(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/user/UserHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/user/UserHandlerTest.java
@@ -1,0 +1,106 @@
+package co.com.bancolombia.api.user;
+
+import co.com.bancolombia.api.dto.user.CreateUserDto;
+import co.com.bancolombia.api.dto.user.UserResponse;
+import co.com.bancolombia.api.mapper.UserMapper;
+import co.com.bancolombia.model.user.User;
+import co.com.bancolombia.usecase.user.CreateUserUseCase;
+import co.com.bancolombia.usecase.user.GetUserUseCase;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserHandlerTest {
+
+    @Mock private Validator validator;
+    @Mock private CreateUserUseCase createUserUseCase;
+    @Mock private GetUserUseCase getUserUseCase;
+    @Mock private UserMapper mapper;
+    @Mock private ServerRequest serverRequest;
+
+    private UserHandler handler;
+
+    private final User user = User.builder()
+            .id("user-1").fullName("María García").email("maria@test.com").build();
+
+    private final UserResponse userResponse = new UserResponse(
+            "user-1", "María García", "maria@test.com",
+            null, "Medellín", "Antioquia", "Colombia", false);
+
+    @BeforeEach
+    void setUp() {
+        handler = new UserHandler(validator, createUserUseCase, getUserUseCase, mapper);
+        lenient().when(validator.validate(any())).thenReturn(Set.of());
+    }
+
+    @Test
+    void createUser_withValidData_returns201WithUserResponse() {
+        CreateUserDto dto = new CreateUserDto();
+        dto.setFullName("María García");
+        dto.setEmail("maria@test.com");
+        dto.setPassword("MiPassw0rd!");
+
+        when(serverRequest.bodyToMono(CreateUserDto.class)).thenReturn(Mono.just(dto));
+        when(mapper.toUser(dto)).thenReturn(user);
+        when(createUserUseCase.execute(user)).thenReturn(Mono.just(user));
+        when(mapper.toResponse(user)).thenReturn(userResponse);
+
+        StepVerifier.create(handler.createUser(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED))
+                .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void createUser_withInvalidData_throwsConstraintViolationException() {
+        CreateUserDto dto = new CreateUserDto();
+        ConstraintViolation<Object> violation = mock(ConstraintViolation.class);
+
+        when(serverRequest.bodyToMono(CreateUserDto.class)).thenReturn(Mono.just(dto));
+        when(validator.validate(any())).thenReturn(Set.of(violation));
+
+        StepVerifier.create(handler.createUser(serverRequest))
+                .expectError(ConstraintViolationException.class)
+                .verify();
+    }
+
+    @Test
+    void getUser_whenUserExists_returns200WithUserResponse() {
+        when(serverRequest.pathVariable("id")).thenReturn("user-1");
+        when(getUserUseCase.execute("user-1")).thenReturn(Mono.just(user));
+        when(mapper.toResponse(user)).thenReturn(userResponse);
+
+        StepVerifier.create(handler.getUser(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+
+    @Test
+    void getUser_whenUserNotFound_propagatesError() {
+        when(serverRequest.pathVariable("id")).thenReturn("unknown");
+        when(getUserUseCase.execute("unknown")).thenReturn(Mono.error(
+                new co.com.bancolombia.model.exception.NotFoundException("USER_NOT_FOUND", "No encontrado")));
+
+        StepVerifier.create(handler.getUser(serverRequest))
+                .expectError(co.com.bancolombia.model.exception.NotFoundException.class)
+                .verify();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/user/UserHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/user/UserHandlerTest.java
@@ -42,8 +42,8 @@ class UserHandlerTest {
             .id("user-1").fullName("María García").email("maria@test.com").build();
 
     private final UserResponse userResponse = new UserResponse(
-            "user-1", "María García", "maria@test.com",
-            null, "Medellín", "Antioquia", "Colombia", false);
+            "user-1", "María García",null, "Medellín", "Antioquia",
+            "Colombia", false);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## Summary

- Agrega `GetUserUseCase` que busca un usuario por ID y lanza `NotFoundException` si no existe
- Nuevo endpoint `GET /api/user/{id}` que retorna `UserResponse` (sin datos sensibles: sin passwordHash, isActive, timestamps)
- `POST /api/user` ahora también retorna `UserResponse` en lugar de la entidad completa
- Reorganización de DTOs en subpaquetes (`user/`, `token/`, `common/`) para mayor cohesión
- Eliminación de dependencias Cucumber incompatibles con Spring Boot 4 / JUnit Platform 6.x

## Tests añadidos

- [x] `GetUserUseCaseTest` — happy path y usuario no encontrado
- [x] `CreateUserUseCaseTest`
- [x] `LoginUseCaseTest`, `LogoutUseCaseTest`, `RefreshTokenUseCaseTest`, `RequestPasswordResetUseCaseTest`, `ResetPasswordUseCaseTest`
- [x] `UserRepositoryAdapterTest`, `RefreshTokenRepositoryAdapterTest`, `PasswordResetRepositoryAdapterTest`
- [x] `PostgreSQLConnectionPoolTest`, `PostgresqlConnectionPropertiesTest`
- [x] `UserHandlerTest`, `AuthHandlerTest`

## Test plan

- [x] Ejecutar `./gradlew test` y verificar que todos los tests pasan
- [x] Verificar que `GET /api/user/{id}` con ID válido retorna 200 con `UserResponse`
- [x] Verificar que `GET /api/user/{id}` con ID inexistente retorna 404 con `errorCode: USER_NOT_FOUND`
- [x] Verificar que `POST /api/user` retorna `UserResponse` (no expone `passwordHash`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)