### PR TITLE
feat(auth): implementar GET /api/auth/validate para validación de token JWT #6

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'org.springframework.boot'
 dependencies {
 	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
 	implementation project(':r2dbc-postgresql')
+	implementation project(':jwt-provider')
 	implementation project(':reactive-web')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
     runtimeOnly('org.springframework.boot:spring-boot-devtools')
     testImplementation 'com.tngtech.archunit:archunit:1.4.1'

--- a/applications/app-service/src/main/java/co/com/bancolombia/config/security/JwtTokenProviderAdapter.java
+++ b/applications/app-service/src/main/java/co/com/bancolombia/config/security/JwtTokenProviderAdapter.java
@@ -1,10 +1,13 @@
 package co.com.bancolombia.config.security;
 
+import co.com.bancolombia.model.auth.TokenClaims;
+import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.model.user.User;
 import co.com.bancolombia.model.user.gateways.TokenProvider;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
@@ -21,13 +25,14 @@ import java.util.UUID;
 public class JwtTokenProviderAdapter implements TokenProvider {
 
     private final RSAPrivateKey rsaPrivateKey;
+    private final RSAPublicKey rsaPublicKey;
     private final JwtProperties jwtProperties;
 
     @Override
     public Mono<String> generateAccessToken(User user) {
         return Mono.fromCallable(() -> {
             Instant now = Instant.now();
-            Instant expiry = now.plusSeconds(jwtProperties.accessTokenExpirationMinutes() * 60);
+            Instant expiry = now.plusSeconds(jwtProperties.accessTokenExpirationMinutes() * 60L);
 
             JWTClaimsSet claims = new JWTClaimsSet.Builder()
                     .subject(user.getEmail())
@@ -44,6 +49,33 @@ public class JwtTokenProviderAdapter implements TokenProvider {
             );
             jwt.sign(new RSASSASigner(rsaPrivateKey));
             return jwt.serialize();
+        });
+    }
+
+    @Override
+    public Mono<TokenClaims> validateToken(String token) {
+        return Mono.fromCallable(() -> {
+            try {
+                SignedJWT jwt = SignedJWT.parse(token);
+
+                if (!jwt.verify(new RSASSAVerifier(rsaPublicKey))) {
+                    throw new UnauthorizedException("INVALID_TOKEN", "Token inválido");
+                }
+
+                JWTClaimsSet claims = jwt.getJWTClaimsSet();
+
+                if (claims.getExpirationTime().before(new Date())) {
+                    throw new UnauthorizedException("TOKEN_EXPIRED", "Token expirado");
+                }
+
+                return TokenClaims.builder()
+                        .userId(claims.getStringClaim("userId"))
+                        .build();
+            } catch (UnauthorizedException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new UnauthorizedException("INVALID_TOKEN", "Token inválido");
+            }
         });
     }
 }

--- a/applications/app-service/src/main/java/co/com/bancolombia/config/security/SecurityConfig.java
+++ b/applications/app-service/src/main/java/co/com/bancolombia/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.config.security;
 
+import co.com.bancolombia.jwt.JwtProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/domain/model/src/main/java/co/com/bancolombia/model/auth/TokenClaims.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/auth/TokenClaims.java
@@ -1,0 +1,14 @@
+package co.com.bancolombia.model.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenClaims {
+    private String userId;
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/user/gateways/TokenProvider.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/user/gateways/TokenProvider.java
@@ -1,8 +1,10 @@
 package co.com.bancolombia.model.user.gateways;
 
+import co.com.bancolombia.model.auth.TokenClaims;
 import co.com.bancolombia.model.user.User;
 import reactor.core.publisher.Mono;
 
 public interface TokenProvider {
     Mono<String> generateAccessToken(User user);
+    Mono<TokenClaims> validateToken(String token);
 }

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/security/ValidateTokenUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/security/ValidateTokenUseCase.java
@@ -1,0 +1,16 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.TokenClaims;
+import co.com.bancolombia.model.user.gateways.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class ValidateTokenUseCase {
+
+    private final TokenProvider tokenProvider;
+
+    public Mono<TokenClaims> execute(String token) {
+        return tokenProvider.validateToken(token);
+    }
+}

--- a/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/ValidateTokenUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/bancolombia/usecase/security/ValidateTokenUseCaseTest.java
@@ -1,0 +1,64 @@
+package co.com.bancolombia.usecase.security;
+
+import co.com.bancolombia.model.auth.TokenClaims;
+import co.com.bancolombia.model.exception.UnauthorizedException;
+import co.com.bancolombia.model.user.gateways.TokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ValidateTokenUseCaseTest {
+
+    @Mock private TokenProvider tokenProvider;
+
+    private ValidateTokenUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidateTokenUseCase(tokenProvider);
+    }
+
+    @Test
+    void execute_withValidToken_returnsClaims() {
+        TokenClaims claims = TokenClaims.builder().userId("user-1").build();
+        when(tokenProvider.validateToken("valid.token")).thenReturn(Mono.just(claims));
+
+        StepVerifier.create(useCase.execute("valid.token"))
+                .assertNext(result -> assertThat(result.getUserId()).isEqualTo("user-1"))
+                .verifyComplete();
+    }
+
+    @Test
+    void execute_withInvalidToken_throwsUnauthorizedException() {
+        when(tokenProvider.validateToken("bad.token"))
+                .thenReturn(Mono.error(new UnauthorizedException("INVALID_TOKEN", "Token inválido")));
+
+        StepVerifier.create(useCase.execute("bad.token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("INVALID_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void execute_withExpiredToken_throwsUnauthorizedException() {
+        when(tokenProvider.validateToken("expired.token"))
+                .thenReturn(Mono.error(new UnauthorizedException("TOKEN_EXPIRED", "Token expirado")));
+
+        StepVerifier.create(useCase.execute("expired.token"))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("TOKEN_EXPIRED");
+                })
+                .verify();
+    }
+}

--- a/infrastructure/driven-adapters/jwt-provider/build.gradle
+++ b/infrastructure/driven-adapters/jwt-provider/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+}

--- a/infrastructure/driven-adapters/jwt-provider/src/main/java/co/com/bancolombia/jwt/JwtProperties.java
+++ b/infrastructure/driven-adapters/jwt-provider/src/main/java/co/com/bancolombia/jwt/JwtProperties.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.config.security;
+package co.com.bancolombia.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/infrastructure/driven-adapters/jwt-provider/src/main/java/co/com/bancolombia/jwt/JwtTokenProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt-provider/src/main/java/co/com/bancolombia/jwt/JwtTokenProviderAdapter.java
@@ -1,4 +1,4 @@
-package co.com.bancolombia.config.security;
+package co.com.bancolombia.jwt;
 
 import co.com.bancolombia.model.auth.TokenClaims;
 import co.com.bancolombia.model.exception.UnauthorizedException;
@@ -11,6 +11,7 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
@@ -20,9 +21,12 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProviderAdapter implements TokenProvider {
+
+    private static final String EXPECTED_ISSUER = "ms-user";
 
     private final RSAPrivateKey rsaPrivateKey;
     private final RSAPublicKey rsaPublicKey;
@@ -36,7 +40,7 @@ public class JwtTokenProviderAdapter implements TokenProvider {
 
             JWTClaimsSet claims = new JWTClaimsSet.Builder()
                     .subject(user.getEmail())
-                    .issuer("ms-user")
+                    .issuer(EXPECTED_ISSUER)
                     .issueTime(Date.from(now))
                     .expirationTime(Date.from(expiry))
                     .jwtID(UUID.randomUUID().toString())
@@ -64,7 +68,12 @@ public class JwtTokenProviderAdapter implements TokenProvider {
 
                 JWTClaimsSet claims = jwt.getJWTClaimsSet();
 
-                if (claims.getExpirationTime().before(new Date())) {
+                if (!EXPECTED_ISSUER.equals(claims.getIssuer())) {
+                    throw new UnauthorizedException("INVALID_TOKEN", "Token inválido");
+                }
+
+                Date expiration = claims.getExpirationTime();
+                if (expiration == null || expiration.before(new Date())) {
                     throw new UnauthorizedException("TOKEN_EXPIRED", "Token expirado");
                 }
 
@@ -74,6 +83,7 @@ public class JwtTokenProviderAdapter implements TokenProvider {
             } catch (UnauthorizedException e) {
                 throw e;
             } catch (Exception e) {
+                log.warn("Token validation failed unexpectedly: {}", e.getMessage());
                 throw new UnauthorizedException("INVALID_TOKEN", "Token inválido");
             }
         });

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.api.auth;
 
+import co.com.bancolombia.api.dto.token.TokenValidationResponse;
 import co.com.bancolombia.api.dto.user.LoginRequest;
 import co.com.bancolombia.api.dto.token.MessageResponse;
 import co.com.bancolombia.api.dto.token.PasswordResetRequest;
@@ -7,11 +8,13 @@ import co.com.bancolombia.api.dto.token.RefreshRequest;
 import co.com.bancolombia.api.dto.token.ResetPasswordRequest;
 import co.com.bancolombia.api.dto.token.TokenResponse;
 import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.usecase.security.LoginUseCase;
 import co.com.bancolombia.usecase.security.LogoutUseCase;
 import co.com.bancolombia.usecase.security.RefreshTokenUseCase;
 import co.com.bancolombia.usecase.security.RequestPasswordResetUseCase;
 import co.com.bancolombia.usecase.security.ResetPasswordUseCase;
+import co.com.bancolombia.usecase.security.ValidateTokenUseCase;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -32,6 +35,7 @@ public class AuthHandler {
     private final RefreshTokenUseCase refreshTokenUseCase;
     private final RequestPasswordResetUseCase requestPasswordResetUseCase;
     private final ResetPasswordUseCase resetPasswordUseCase;
+    private final ValidateTokenUseCase validateTokenUseCase;
     private final Validator validator;
 
     private static final String PASSWORD_RESET_MESSAGE =
@@ -75,6 +79,17 @@ public class AuthHandler {
                 .doOnNext(this::validate)
                 .flatMap(req -> resetPasswordUseCase.execute(req.token(), req.newPassword()))
                 .then(ServerResponse.ok().bodyValue(new MessageResponse("Contraseña actualizada correctamente")));
+    }
+
+    public Mono<ServerResponse> validateToken(ServerRequest request) {
+        String authHeader = request.headers().firstHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return Mono.error(new UnauthorizedException("MISSING_TOKEN", "Token no proporcionado"));
+        }
+        String token = authHeader.substring(7);
+        return validateTokenUseCase.execute(token)
+                .flatMap(claims -> ServerResponse.ok()
+                        .bodyValue(new TokenValidationResponse(claims.getUserId())));
     }
 
     private void validate(Object dto) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthHandler.java
@@ -19,6 +19,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -82,7 +83,7 @@ public class AuthHandler {
     }
 
     public Mono<ServerResponse> validateToken(ServerRequest request) {
-        String authHeader = request.headers().firstHeader("Authorization");
+        String authHeader = request.headers().firstHeader(HttpHeaders.AUTHORIZATION);
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             return Mono.error(new UnauthorizedException("MISSING_TOKEN", "Token no proporcionado"));
         }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/auth/AuthRouterRest.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.api.auth;
 
 import co.com.bancolombia.api.dto.common.ErrorResponse;
+import co.com.bancolombia.api.dto.token.TokenValidationResponse;
 import co.com.bancolombia.api.dto.user.LoginRequest;
 import co.com.bancolombia.api.dto.token.MessageResponse;
 import co.com.bancolombia.api.dto.token.PasswordResetRequest;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
 import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
@@ -209,6 +211,38 @@ public class AuthRouterRest {
             )
         ),
         @RouterOperation(
+            path = "/api/auth/validate",
+            method = RequestMethod.GET,
+            beanClass = AuthHandler.class,
+            beanMethod = "validateToken",
+            operation = @Operation(
+                operationId = "validateToken",
+                summary = "Validar token JWT",
+                description = "Valida un token JWT y retorna los claims del usuario. "
+                            + "Usado principalmente por el API Gateway para autorizar requests entrantes. "
+                            + "El token debe enviarse en el header Authorization como Bearer token.",
+                tags = {"Autenticación"},
+                responses = {
+                    @ApiResponse(
+                        responseCode = "200",
+                        description = "Token válido. Retorna los claims del usuario.",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = TokenValidationResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Token ausente, inválido o expirado",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
+        ),
+        @RouterOperation(
             path = "/api/auth/password-reset/confirm",
             method = RequestMethod.POST,
             beanClass = AuthHandler.class,
@@ -252,6 +286,7 @@ public class AuthRouterRest {
         return route(POST("/api/auth/login"), authHandler::login)
                 .andRoute(POST("/api/auth/refresh"), authHandler::refresh)
                 .andRoute(POST("/api/auth/logout"), authHandler::logout)
+                .andRoute(GET("/api/auth/validate"), authHandler::validateToken)
                 .andRoute(POST("/api/auth/password-reset/request"), authHandler::requestPasswordReset)
                 .andRoute(POST("/api/auth/password-reset/confirm"), authHandler::resetPassword);
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/TokenValidationResponse.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/token/TokenValidationResponse.java
@@ -1,0 +1,4 @@
+package co.com.bancolombia.api.dto.token;
+
+public record TokenValidationResponse(String userId) {
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
@@ -141,7 +141,7 @@ class AuthHandlerTest {
     }
 
     @Test
-    void validateToken_withValidBearerToken_returns200WithUserId() {
+    void validateToken_withValidBearerToken_returns200() {
         TokenClaims claims = TokenClaims.builder().userId("user-1").build();
 
         when(serverRequest.headers()).thenReturn(headers);

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/auth/AuthHandlerTest.java
@@ -7,11 +7,14 @@ import co.com.bancolombia.api.dto.token.TokenResponse;
 import co.com.bancolombia.api.dto.user.LoginRequest;
 import co.com.bancolombia.model.auth.TokenPair;
 import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.auth.TokenClaims;
+import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.usecase.security.LoginUseCase;
 import co.com.bancolombia.usecase.security.LogoutUseCase;
 import co.com.bancolombia.usecase.security.RefreshTokenUseCase;
 import co.com.bancolombia.usecase.security.RequestPasswordResetUseCase;
 import co.com.bancolombia.usecase.security.ResetPasswordUseCase;
+import co.com.bancolombia.usecase.security.ValidateTokenUseCase;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -30,6 +33,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +45,7 @@ class AuthHandlerTest {
     @Mock private RefreshTokenUseCase refreshTokenUseCase;
     @Mock private RequestPasswordResetUseCase requestPasswordResetUseCase;
     @Mock private ResetPasswordUseCase resetPasswordUseCase;
+    @Mock private ValidateTokenUseCase validateTokenUseCase;
     @Mock private Validator validator;
     @Mock private ServerRequest serverRequest;
     @Mock private ServerRequest.Headers headers;
@@ -50,8 +55,8 @@ class AuthHandlerTest {
     @BeforeEach
     void setUp() {
         handler = new AuthHandler(loginUseCase, logoutUseCase, refreshTokenUseCase,
-                requestPasswordResetUseCase, resetPasswordUseCase, validator);
-        when(validator.validate(any())).thenReturn(Set.of());
+                requestPasswordResetUseCase, resetPasswordUseCase, validateTokenUseCase, validator);
+        lenient().when(validator.validate(any())).thenReturn(Set.of());
     }
 
     @Test
@@ -133,6 +138,60 @@ class AuthHandlerTest {
         StepVerifier.create(handler.requestPasswordReset(serverRequest))
                 .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
                 .verifyComplete();
+    }
+
+    @Test
+    void validateToken_withValidBearerToken_returns200WithUserId() {
+        TokenClaims claims = TokenClaims.builder().userId("user-1").build();
+
+        when(serverRequest.headers()).thenReturn(headers);
+        when(headers.firstHeader("Authorization")).thenReturn("Bearer valid.jwt.token");
+        when(validateTokenUseCase.execute("valid.jwt.token")).thenReturn(Mono.just(claims));
+
+        StepVerifier.create(handler.validateToken(serverRequest))
+                .assertNext(response -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateToken_withMissingAuthorizationHeader_throwsUnauthorizedException() {
+        when(serverRequest.headers()).thenReturn(headers);
+        when(headers.firstHeader("Authorization")).thenReturn(null);
+
+        StepVerifier.create(handler.validateToken(serverRequest))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("MISSING_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void validateToken_withNonBearerHeader_throwsUnauthorizedException() {
+        when(serverRequest.headers()).thenReturn(headers);
+        when(headers.firstHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+        StepVerifier.create(handler.validateToken(serverRequest))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("MISSING_TOKEN");
+                })
+                .verify();
+    }
+
+    @Test
+    void validateToken_withExpiredToken_throwsUnauthorizedException() {
+        when(serverRequest.headers()).thenReturn(headers);
+        when(headers.firstHeader("Authorization")).thenReturn("Bearer expired.token");
+        when(validateTokenUseCase.execute("expired.token"))
+                .thenReturn(Mono.error(new UnauthorizedException("TOKEN_EXPIRED", "Token expirado")));
+
+        StepVerifier.create(handler.validateToken(serverRequest))
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(UnauthorizedException.class);
+                    assertThat(((UnauthorizedException) error).getErrorCode()).isEqualTo("TOKEN_EXPIRED");
+                })
+                .verify();
     }
 
     @Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,3 +23,5 @@ include ':reactive-web'
 project(':reactive-web').projectDir = file('./infrastructure/entry-points/reactive-web')
 include ':r2dbc-postgresql'
 project(':r2dbc-postgresql').projectDir = file('./infrastructure/driven-adapters/r2dbc-postgresql')
+include ':jwt-provider'
+project(':jwt-provider').projectDir = file('./infrastructure/driven-adapters/jwt-provider')


### PR DESCRIPTION
## Descripción

Implementa el endpoint `GET /api/auth/validate` para validación de tokens JWT, requerido por el API Gateway para autorizar requests entrantes hacia los demás microservicios del ecosistema.

Cierra #6

## Cambios

- **`TokenClaims`** — nuevo modelo de dominio con solo `userId` (sin PII como email)
- **`TokenProvider`** — nuevo método `validateToken(String token)` en el gateway
- **`ValidateTokenUseCase`** — nuevo caso de uso que delega la validación al gateway
- **`JwtTokenProviderAdapter`** — implementa `validateToken` con verificación de firma RSA y expiración; errores de Nimbus (`ParseException`, `JOSEException`) se envuelven en `UnauthorizedException` para garantizar 401 en lugar de 500
- **`TokenValidationResponse`** — DTO de respuesta con `userId`
- **`AuthHandler`** — nuevo método `validateToken`, extrae Bearer token del header `Authorization`
- **`AuthRouterRest`** — ruta `GET /api/auth/validate` con documentación OpenAPI

## Decisiones técnicas

- **Email excluido de la respuesta**: es dato sensible (PII). El API Gateway solo necesita `userId` para enriquecer requests; si un ms necesita el email, lo consulta directamente a ms-user.
- **Sin refresh token en la respuesta**: el refresh es un flujo separado del cliente, no del Gateway.
- **401 en tokens mal formados**: captura de excepciones de Nimbus para evitar que lleguen como 500 al `GlobalErrorHandler`.

## Test plan

- [x] `ValidateTokenUseCaseTest` — token válido, inválido y expirado
- [x] `AuthHandlerTest` — Bearer válido, header ausente, header no-Bearer, token expirado

🤖 Generated with [Claude Code](https://claude.com/claude-code)